### PR TITLE
Add multiple condition support

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ if (event != "pull_request" || payload.action != "closed") {
 With:
 
 ```javascript
-await require("action-guard")("pull_request.closed");
+require("action-guard")("pull_request.closed");
 ```
 
 If you're looking for a way to handle multiple events + actions, you might find [@mheap/action-router](https://github.com/mheap/action-router) useful
@@ -33,12 +33,12 @@ npm install action-guard
 
 ## Usage
 
-Action Guard will reject if the `GITHUB_EVENT_NAME` does not match what is expected
+Action Guard will throw if the `GITHUB_EVENT_NAME` does not match what is expected
 
 If you're happy to leave it uncaught (leading to a `process.exit(1)`) you can add it as one line:
 
 ```javascript
-await require("action-guard")("pull_request.closed");
+require("action-guard")("pull_request.closed");
 ```
 
 Alternatively, you can wrap it in a try/catch
@@ -47,7 +47,7 @@ Alternatively, you can wrap it in a try/catch
 const guard = require("action-guard");
 
 try {
-  await guard("pull_request.closed");
+  guard("pull_request.closed");
 } catch (e) {
   // It didn't match. Let's do something else
 }
@@ -55,10 +55,10 @@ try {
 
 ### Matching multiple conditions
 
-You can provide multiple conditions to validate. If any of them pass, the promise will `resolve`. If all fail, the promise will `reject`.
+You can provide multiple conditions to validate. If all fail, an `Error` will be thrown.
 
 Here's an example that allows an action to run when closing an `issue` or `pull_request`:
 
 ```javascript
-await guard(["issue.closed", "pull_request.closed"]);
+guard(["issue.closed", "pull_request.closed"]);
 ```

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ if (event != "pull_request" || payload.action != "closed") {
 With:
 
 ```javascript
-require("action-guard")("pull_request.closed");
+await require("action-guard")("pull_request.closed");
 ```
 
 If you're looking for a way to handle multiple events + actions, you might find [@mheap/action-router](https://github.com/mheap/action-router) useful
@@ -33,12 +33,12 @@ npm install action-guard
 
 ## Usage
 
-Action Guard will throw an error if the `GITHUB_EVENT_NAME` does not match what is expected
+Action Guard will reject if the `GITHUB_EVENT_NAME` does not match what is expected
 
 If you're happy to leave it uncaught (leading to a `process.exit(1)`) you can add it as one line:
 
 ```javascript
-require("action-guard")("pull_request.closed");
+await require("action-guard")("pull_request.closed");
 ```
 
 Alternatively, you can wrap it in a try/catch
@@ -47,8 +47,18 @@ Alternatively, you can wrap it in a try/catch
 const guard = require("action-guard");
 
 try {
-  guard("pull_request.closed");
+  await guard("pull_request.closed");
 } catch (e) {
   // It didn't match. Let's do something else
 }
+```
+
+### Matching multiple conditions
+
+You can provide multiple conditions to validate. If any of them pass, the promise will `resolve`. If all fail, the promise will `reject`.
+
+Here's an example that allows an action to run when closing an `issue` or `pull_request`:
+
+```javascript
+await guard(["issue.closed", "pull_request.closed"]);
 ```

--- a/index.js
+++ b/index.js
@@ -4,37 +4,31 @@ module.exports = (guards) => {
   }
   let prefix = "";
 
-  return new Promise(async (resolve, reject) => {
-    // Make sure we have the required ENV parameters
-    const requiredEnv = ["GITHUB_EVENT_NAME", "GITHUB_EVENT_PATH"];
+  // Make sure we have the required ENV parameters
+  const requiredEnv = ["GITHUB_EVENT_NAME", "GITHUB_EVENT_PATH"];
 
-    for (let name of requiredEnv) {
-      if (!process.env[name]) {
-        return reject(`Missing required environment variable: ${name}`);
-      }
+  for (let name of requiredEnv) {
+    if (!process.env[name]) {
+      throw new Error(`Missing required environment variable: ${name}`);
     }
+  }
 
-    const promises = [];
-    for (let guard of guards) {
-      promises.push(runSingle(guard));
+  const results = [];
+  for (let guard of guards) {
+    results.push(runSingle(guard));
+  }
+
+  const failed = results.filter((r) => r.success === false);
+
+  if (failed.length === results.length) {
+    const errors = failed.map((r) => r.reason).join("\n");
+
+    // If we're checking multiple guards, add a prefix
+    if (guards.length > 1) {
+      prefix = "Expected at least one to pass, but all guards failed:\n\n";
     }
-
-    const results = await Promise.allSettled(promises);
-
-    const rejected = results.filter((r) => r.status === "rejected");
-
-    if (rejected.length === results.length) {
-      const errors = rejected.map((r) => r.reason).join("\n");
-
-      // If we're checking multiple guards, add a prefix
-      if (guards.length > 1) {
-        prefix = "Expected at least one to pass, but all guards failed:\n\n";
-      }
-      return reject(`${prefix}${errors}`);
-    }
-
-    return resolve();
-  });
+    throw new Error(`${prefix}${errors}`);
+  }
 };
 
 function runSingle(params) {
@@ -42,25 +36,25 @@ function runSingle(params) {
     params = { event: params };
   }
   let expectedEventName = params.event;
-  return new Promise((resolve, reject) => {
-    // Save the event name and payload
-    const event = process.env.GITHUB_EVENT_NAME;
-    const payload = require(process.env.GITHUB_EVENT_PATH);
+  // Save the event name and payload
+  const event = process.env.GITHUB_EVENT_NAME;
+  const payload = require(process.env.GITHUB_EVENT_PATH);
 
-    // Check that the provided event matches what we're expecting
-    let [expectedEvent, expectedAction] = expectedEventName.split(".", 2);
-    if (event !== expectedEvent) {
-      return reject(
-        `Invalid event. Expected '${expectedEvent}', got '${event}'`
-      );
-    }
+  // Check that the provided event matches what we're expecting
+  let [expectedEvent, expectedAction] = expectedEventName.split(".", 2);
+  if (event !== expectedEvent) {
+    return {
+      success: false,
+      reason: `Invalid event. Expected '${expectedEvent}', got '${event}'`,
+    };
+  }
 
-    if (expectedAction && payload.action !== expectedAction) {
-      return reject(
-        `Invalid event. Expected '${expectedEvent}.${expectedAction}', got '${event}.${payload.action}'`
-      );
-    }
+  if (expectedAction && payload.action !== expectedAction) {
+    return {
+      success: false,
+      reason: `Invalid event. Expected '${expectedEvent}.${expectedAction}', got '${event}.${payload.action}'`,
+    };
+  }
 
-    return resolve();
-  });
+  return { success: true };
 }

--- a/index.js
+++ b/index.js
@@ -1,28 +1,32 @@
 module.exports = (expectedEventName) => {
-  // Make sure we have the required ENV parameters
-  const requiredEnv = ["GITHUB_EVENT_NAME", "GITHUB_EVENT_PATH"];
+  return new Promise((resolve, reject) => {
+    // Make sure we have the required ENV parameters
+    const requiredEnv = ["GITHUB_EVENT_NAME", "GITHUB_EVENT_PATH"];
 
-  for (let name of requiredEnv) {
-    if (!process.env[name]) {
-      throw new Error(`Missing required environment variable: ${name}`);
+    for (let name of requiredEnv) {
+      if (!process.env[name]) {
+        return reject(`Missing required environment variable: ${name}`);
+      }
     }
-  }
 
-  // Save the event name and payload
-  const event = process.env.GITHUB_EVENT_NAME;
-  const payload = require(process.env.GITHUB_EVENT_PATH);
+    // Save the event name and payload
+    const event = process.env.GITHUB_EVENT_NAME;
+    const payload = require(process.env.GITHUB_EVENT_PATH);
 
-  // Check that the provided event matches what we're expecting
-  let [expectedEvent, expectedAction] = expectedEventName.split(".", 2);
-  if (event !== expectedEvent) {
-    throw new Error(
-      `Invalid event. Expected '${expectedEvent}', got '${event}'`
-    );
-  }
+    // Check that the provided event matches what we're expecting
+    let [expectedEvent, expectedAction] = expectedEventName.split(".", 2);
+    if (event !== expectedEvent) {
+      return reject(
+        `Invalid event. Expected '${expectedEvent}', got '${event}'`
+      );
+    }
 
-  if (payload.action !== expectedAction) {
-    throw new Error(
-      `Invalid event. Expected '${expectedEvent}.${expectedAction}', got '${event}.${payload.action}'`
-    );
-  }
+    if (payload.action !== expectedAction) {
+      return reject(
+        `Invalid event. Expected '${expectedEvent}.${expectedAction}', got '${event}.${payload.action}'`
+      );
+    }
+
+    return resolve();
+  });
 };

--- a/index.test.js
+++ b/index.test.js
@@ -10,41 +10,49 @@ describe("Action Guard", () => {
   });
 
   describe("Check ENV variables", () => {
-    it("rejects if GITHUB_EVENT_NAME is not set", () => {
-      return expect(guard).rejects.toBe(
-        "Missing required environment variable: GITHUB_EVENT_NAME"
+    it("throws if GITHUB_EVENT_NAME is not set", () => {
+      expect(guard).toThrow(
+        new Error("Missing required environment variable: GITHUB_EVENT_NAME")
       );
     });
 
-    it("rejects if GITHUB_EVENT_PATH is not set", () => {
+    it("throws if GITHUB_EVENT_PATH is not set", () => {
       restore = mockedEnv({
         GITHUB_EVENT_NAME: "push",
       });
-      return expect(guard).rejects.toBe(
-        "Missing required environment variable: GITHUB_EVENT_PATH"
+      expect(guard).toThrow(
+        new Error("Missing required environment variable: GITHUB_EVENT_PATH")
       );
     });
   });
 
   describe("Event Check", () => {
-    it("rejects if the GITHUB_EVENT_NAME does not match (event only)", () => {
+    it("throws if the GITHUB_EVENT_NAME does not match (event only)", () => {
       mockEvent("pull_request", { action: "opened" });
-      return expect(guard("push")).rejects.toBe(
-        "Invalid event. Expected 'push', got 'pull_request'"
+      expect(() => {
+        guard("push");
+      }).toThrow(
+        new Error("Invalid event. Expected 'push', got 'pull_request'")
       );
     });
 
-    it("rejects if the GITHUB_EVENT_NAME does not match (event + action)", () => {
+    it("throws if the GITHUB_EVENT_NAME does not match (event + action)", () => {
       mockEvent("pull_request", { action: "opened" });
-      return expect(guard("issue.opened")).rejects.toBe(
-        "Invalid event. Expected 'issue', got 'pull_request'"
+      expect(() => {
+        guard("issue.opened");
+      }).toThrow(
+        new Error("Invalid event. Expected 'issue', got 'pull_request'")
       );
     });
 
-    it("rejects if the action does not match (event + action)", () => {
+    it("throws if the action does not match (event + action)", () => {
       mockEvent("pull_request", { action: "closed" });
-      expect(guard("pull_request.opened")).rejects.toBe(
-        "Invalid event. Expected 'pull_request.opened', got 'pull_request.closed'"
+      expect(() => {
+        guard("pull_request.opened");
+      }).toThrow(
+        new Error(
+          "Invalid event. Expected 'pull_request.opened', got 'pull_request.closed'"
+        )
       );
     });
   });
@@ -52,46 +60,48 @@ describe("Action Guard", () => {
   describe("Calling formats", () => {
     it("string", () => {
       mockEvent("pull_request", { action: "opened" });
-      return expect(guard("push")).rejects.toBe(
-        "Invalid event. Expected 'push', got 'pull_request'"
-      );
+      return expect(() => {
+        guard("push");
+      }).toThrow("Invalid event. Expected 'push', got 'pull_request'");
     });
 
     it("object", () => {
       mockEvent("pull_request", { action: "opened" });
-      return expect(guard({ event: "push" })).rejects.toBe(
-        "Invalid event. Expected 'push', got 'pull_request'"
-      );
+      return expect(() => {
+        guard({ event: "push" });
+      }).toThrow("Invalid event. Expected 'push', got 'pull_request'");
     });
 
     it("array of strings", () => {
       mockEvent("pull_request", { action: "opened" });
-      return expect(guard(["push"])).rejects.toBe(
-        "Invalid event. Expected 'push', got 'pull_request'"
-      );
+      return expect(() => {
+        guard(["push"]);
+      }).toThrow("Invalid event. Expected 'push', got 'pull_request'");
     });
 
     it("array of objects", () => {
       mockEvent("pull_request", { action: "opened" });
-      return expect(guard([{ event: "push" }])).rejects.toBe(
-        "Invalid event. Expected 'push', got 'pull_request'"
-      );
+      return expect(() => {
+        guard([{ event: "push" }]);
+      }).toThrow("Invalid event. Expected 'push', got 'pull_request'");
     });
   });
 
   describe("Multiple Guards", () => {
-    it("rejects if all guards fail (string)", () => {
+    it("throws if all guards fail (string)", () => {
       mockEvent("issue", { action: "opened" });
-      return expect(guard(["push", "pull_request"])).rejects.toBe(
+      return expect(() => {
+        guard(["push", "pull_request"]);
+      }).toThrow(
         "Expected at least one to pass, but all guards failed:\n\nInvalid event. Expected 'push', got 'issue'\nInvalid event. Expected 'pull_request', got 'issue'"
       );
     });
 
-    it("rejects if all guards fail (object)", () => {
+    it("throws if all guards fail (object)", () => {
       mockEvent("issue", { action: "opened" });
-      return expect(
-        guard([{ event: "push" }, { event: "pull_request" }])
-      ).rejects.toBe(
+      return expect(() => {
+        guard([{ event: "push" }, { event: "pull_request" }]);
+      }).toThrow(
         "Expected at least one to pass, but all guards failed:\n\nInvalid event. Expected 'push', got 'issue'\nInvalid event. Expected 'pull_request', got 'issue'"
       );
     });

--- a/index.test.js
+++ b/index.test.js
@@ -48,6 +48,54 @@ describe("Action Guard", () => {
       );
     });
   });
+
+  describe("Calling formats", () => {
+    it("string", () => {
+      mockEvent("pull_request", { action: "opened" });
+      return expect(guard("push")).rejects.toBe(
+        "Invalid event. Expected 'push', got 'pull_request'"
+      );
+    });
+
+    it("object", () => {
+      mockEvent("pull_request", { action: "opened" });
+      return expect(guard({ event: "push" })).rejects.toBe(
+        "Invalid event. Expected 'push', got 'pull_request'"
+      );
+    });
+
+    it("array of strings", () => {
+      mockEvent("pull_request", { action: "opened" });
+      return expect(guard(["push"])).rejects.toBe(
+        "Invalid event. Expected 'push', got 'pull_request'"
+      );
+    });
+
+    it("array of objects", () => {
+      mockEvent("pull_request", { action: "opened" });
+      return expect(guard([{ event: "push" }])).rejects.toBe(
+        "Invalid event. Expected 'push', got 'pull_request'"
+      );
+    });
+  });
+
+  describe("Multiple Guards", () => {
+    it("rejects if all guards fail (string)", () => {
+      mockEvent("issue", { action: "opened" });
+      return expect(guard(["push", "pull_request"])).rejects.toBe(
+        "Expected at least one to pass, but all guards failed:\n\nInvalid event. Expected 'push', got 'issue'\nInvalid event. Expected 'pull_request', got 'issue'"
+      );
+    });
+
+    it("rejects if all guards fail (object)", () => {
+      mockEvent("issue", { action: "opened" });
+      return expect(
+        guard([{ event: "push" }, { event: "pull_request" }])
+      ).rejects.toBe(
+        "Expected at least one to pass, but all guards failed:\n\nInvalid event. Expected 'push', got 'issue'\nInvalid event. Expected 'pull_request', got 'issue'"
+      );
+    });
+  });
 });
 
 function mockEvent(eventName, mockPayload) {

--- a/index.test.js
+++ b/index.test.js
@@ -10,49 +10,41 @@ describe("Action Guard", () => {
   });
 
   describe("Check ENV variables", () => {
-    it("throws if GITHUB_EVENT_NAME is not set", () => {
-      expect(guard).toThrow(
-        new Error("Missing required environment variable: GITHUB_EVENT_NAME")
+    it("rejects if GITHUB_EVENT_NAME is not set", () => {
+      return expect(guard).rejects.toBe(
+        "Missing required environment variable: GITHUB_EVENT_NAME"
       );
     });
 
-    it("throws if GITHUB_EVENT_PATH is not set", () => {
+    it("rejects if GITHUB_EVENT_PATH is not set", () => {
       restore = mockedEnv({
         GITHUB_EVENT_NAME: "push",
       });
-      expect(guard).toThrow(
-        new Error("Missing required environment variable: GITHUB_EVENT_PATH")
+      return expect(guard).rejects.toBe(
+        "Missing required environment variable: GITHUB_EVENT_PATH"
       );
     });
   });
 
   describe("Event Check", () => {
-    it("throws if the GITHUB_EVENT_NAME does not match (event only)", () => {
+    it("rejects if the GITHUB_EVENT_NAME does not match (event only)", () => {
       mockEvent("pull_request", { action: "opened" });
-      expect(() => {
-        guard("push");
-      }).toThrow(
-        new Error("Invalid event. Expected 'push', got 'pull_request'")
+      return expect(guard("push")).rejects.toBe(
+        "Invalid event. Expected 'push', got 'pull_request'"
       );
     });
 
-    it("throws if the GITHUB_EVENT_NAME does not match (event + action)", () => {
+    it("rejects if the GITHUB_EVENT_NAME does not match (event + action)", () => {
       mockEvent("pull_request", { action: "opened" });
-      expect(() => {
-        guard("issue.opened");
-      }).toThrow(
-        new Error("Invalid event. Expected 'issue', got 'pull_request'")
+      return expect(guard("issue.opened")).rejects.toBe(
+        "Invalid event. Expected 'issue', got 'pull_request'"
       );
     });
 
-    it("throws if the action does not match (event + action)", () => {
+    it("rejects if the action does not match (event + action)", () => {
       mockEvent("pull_request", { action: "closed" });
-      expect(() => {
-        guard("pull_request.opened");
-      }).toThrow(
-        new Error(
-          "Invalid event. Expected 'pull_request.opened', got 'pull_request.closed'"
-        )
+      expect(guard("pull_request.opened")).rejects.toBe(
+        "Invalid event. Expected 'pull_request.opened', got 'pull_request.closed'"
       );
     });
   });


### PR DESCRIPTION
Resolves #2 

I initially switched to promises (see interim commits) but realised that as we're not performing any async operations it was adding needless complexity. By packaging up the "allow any to pass" functionality and not relying on `allSettled` as shown in #2 we can keep the same user experience